### PR TITLE
Improve docs on how to get the test result details reported

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ Then just run jest and it will test errors PRs!
 ```
 
 ```sh
-jest file.js
+jest --testLocationInResults file.js
 ```
+
+(The `--testLocationInResults` flag is needed to get the in-file checks/annotations, otherwise only the summary comment is shown.)
 
 ## Using your own GitHub App
 


### PR DESCRIPTION
Add needed `jest` flag to Readme example.

I was scratching my head for quite a while trying to figure out why I only got the summary comment and not the (failing) test result details I was hoping for! Hopefully this can make it easier to set up for the next user :-)

Thanks for a nice solution by the way!