### PR TITLE
Allow to pass check name environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ GH_PREVIEWS=eye-scream-preview,machine-man-preview
 
 ### 5. (optional) Set `GH_CHECK_NAME`
 
-If the default check name conflicts with something, you can override it by passing `GITHUB_CHECK_NAME` environment variable.
+If the default check name conflicts with something, you can override it by passing `GH_CHECK_NAME` environment variable.

--- a/README.md
+++ b/README.md
@@ -81,4 +81,6 @@ Example:
 GH_PREVIEWS=eye-scream-preview,machine-man-preview
 ```
 
+### 5. (optional) Set `GH_CHECK_NAME`
 
+If the default check name conflicts with something, you can override it by passing `GITHUB_CHECK_NAME` environment variable.

--- a/src/create-check.ts
+++ b/src/create-check.ts
@@ -95,7 +95,7 @@ function createAnnotations(results: TestResult[]) {
 export default (results: AggregatedResult) =>
   createCheck({
     tool: 'Jest',
-    name: process.env.GITHUB_CHECK_NAME || 'Test',
+    name: process.env.GH_CHECK_NAME || 'Test',
     annotations: createAnnotations(results.testResults),
     errorCount: results.numFailedTests,
     appId: process.env.JEST_APP_ID ? Number(process.env.JEST_APP_ID) : APP_ID,

--- a/src/create-check.ts
+++ b/src/create-check.ts
@@ -95,7 +95,7 @@ function createAnnotations(results: TestResult[]) {
 export default (results: AggregatedResult) =>
   createCheck({
     tool: 'Jest',
-    name: 'Test',
+    name: process.env.GITHUB_CHECK_NAME || 'Test',
     annotations: createAnnotations(results.testResults),
     errorCount: results.numFailedTests,
     appId: process.env.JEST_APP_ID ? Number(process.env.JEST_APP_ID) : APP_ID,


### PR DESCRIPTION
this covers at least two use cases:
1. For some people the check name may conflict with an existing one, if they are using their own github app.
2. In some monorepos there are multiple jest runs happening in series for multiple different packages in scope of one codebuild run. Without an ability to override the check name we are stuck with only last package results being reported.

This would allow to work around those

related pr: https://github.com/hipstersmoothie/eslint-formatter-github/pull/113