### PR TITLE
annotate files relative to git root, instead of cwd, so that it works in nested packages in monorepos

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,11 @@
   "dependencies": {
     "@octokit/rest": "^16.28.7",
     "create-check": "^0.6.40",
+    "execa": "^1.0.0",
     "strip-ansi": "^6.0.0"
   },
   "devDependencies": {
+    "@types/execa": "^0.9.0",
     "@types/node": "12.12.38",
     "@typescript-eslint/eslint-plugin": "2.32.0",
     "@typescript-eslint/parser": "2.32.0",

--- a/src/create-check.ts
+++ b/src/create-check.ts
@@ -5,6 +5,7 @@ import { TestResult, AggregatedResult } from '@jest/reporters';
 import path from 'path';
 import stripAnsi from 'strip-ansi';
 import createCheck, { Annotation } from 'create-check';
+import execa from 'execa';
 
 const APP_ID = 38833;
 /**
@@ -54,7 +55,9 @@ interface Location {
   line: number;
 }
 
-function createAnnotations(results: TestResult[]) {
+async function createAnnotations(results: TestResult[]) {
+  const gitRoot = (await execa('git', ['rev-parse', '--show-toplevel'])).stdout;
+
   const annotations: Annotation[] = [];
 
   for (const result of results) {
@@ -77,7 +80,7 @@ function createAnnotations(results: TestResult[]) {
               : location.line || 0;
 
             annotations.push({
-              path: path.relative(process.cwd(), testFilePath),
+              path: path.relative(gitRoot, testFilePath),
               start_line,
               end_line: start_line,
               annotation_level: 'failure',
@@ -96,7 +99,7 @@ export default (results: AggregatedResult) =>
   createCheck({
     tool: 'Jest',
     name: 'Test',
-    annotations: createAnnotations(results.testResults),
+    annotations: await createAnnotations(results.testResults),
     errorCount: results.numFailedTests,
     appId: process.env.JEST_APP_ID ? Number(process.env.JEST_APP_ID) : APP_ID,
     privateKey: process.env.JEST_PRIVATE_KEY || PRIVATE_KEY

--- a/src/create-check.ts
+++ b/src/create-check.ts
@@ -56,7 +56,7 @@ interface Location {
 }
 
 async function createAnnotations(results: TestResult[]) {
-  const gitRoot = (await execa('git', ['rev-parse', '--show-toplevel'])).stdout;
+  const repoRoot = (await execa('git', ['rev-parse', '--show-toplevel'])).stdout;
 
   const annotations: Annotation[] = [];
 
@@ -80,7 +80,7 @@ async function createAnnotations(results: TestResult[]) {
               : location.line || 0;
 
             annotations.push({
-              path: path.relative(gitRoot, testFilePath),
+              path: path.relative(repoRoot, testFilePath),
               start_line,
               end_line: start_line,
               annotation_level: 'failure',

--- a/src/create-check.ts
+++ b/src/create-check.ts
@@ -5,7 +5,7 @@ import { TestResult, AggregatedResult } from '@jest/reporters';
 import path from 'path';
 import stripAnsi from 'strip-ansi';
 import createCheck, { Annotation } from 'create-check';
-import { execa } from 'execa';
+import execa from 'execa';
 
 const APP_ID = 38833;
 /**

--- a/src/create-check.ts
+++ b/src/create-check.ts
@@ -5,7 +5,7 @@ import { TestResult, AggregatedResult } from '@jest/reporters';
 import path from 'path';
 import stripAnsi from 'strip-ansi';
 import createCheck, { Annotation } from 'create-check';
-import execa from 'execa';
+import { execa } from 'execa';
 
 const APP_ID = 38833;
 /**
@@ -95,7 +95,7 @@ async function createAnnotations(results: TestResult[]) {
   return annotations;
 }
 
-export default (results: AggregatedResult) =>
+export default async (results: AggregatedResult) =>
   createCheck({
     tool: 'Jest',
     name: 'Test',

--- a/yarn.lock
+++ b/yarn.lock
@@ -998,6 +998,13 @@
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
+"@types/execa@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@types/execa/-/execa-0.9.0.tgz#9b025d2755f17e80beaf9368c3f4f319d8b0fb93"
+  integrity sha512-mgfd93RhzjYBUHHV532turHC2j4l/qxsF/PbfDmprHDEUHmNZGlDn1CEsulGK3AfsPdhkWzZQT/S/k0UGhLGsA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.3.tgz#039af35fe26bec35003e8d86d2ee9c586354348f"


### PR DESCRIPTION
probably a major change? 
although very unlikely, but still can break somebody.

confirmed working in our monorepo

used execa v1 instead of the latest one because dependencies already use it. just to dedupe versions